### PR TITLE
Move jupyterlab and pixi-kernel to optional dependencies

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -43,12 +43,12 @@ dependencies = [
   'pandas',      # Displaying tables in Jupyter notebooks
   'plotly',      # Interactive plots
   'py3Dmol',     # Visualisation of crystal structures
-  'jupyterlab',  # Jupyter notebooks
-  'pixi-kernel', # Pixi Jupyter kernel
 ]
 
 [project.optional-dependencies]
 dev = [
+  'jupyterlab',                      # Jupyter notebooks
+  'pixi-kernel',                     # Pixi Jupyter kernel
   'GitPython',                       # Interact with Git repositories
   'build',                           # Building the package
   'pre-commit',                      # Pre-commit hooks


### PR DESCRIPTION
I think we shouldn't add jupyterlab as a dependency for all packages as we don't explicitly need jupyterlab for easy* packages (from what I gather). JupyterLab itself has a big chunk of deps and we should avoid adding them unless absolutely required.

This will also make sure we don't mix jupyterlab bits on VISA.