### PR TITLE
Preserve source-style type annotations in API docs

### DIFF
--- a/template/docs/mkdocs.yml.jinja
+++ b/template/docs/mkdocs.yml.jinja
@@ -162,6 +162,7 @@ plugins:
         python:
           paths: ['src'] # Change 'src' to your actual sources directory
           options:
+            annotations_path: source
             docstring_style: numpy
             group_by_category: false
             heading_level: 1


### PR DESCRIPTION
Configure mkdocstrings with annotations_path: source so the generated API reference renders type annotations exactly as written in the codebase, such as `np.ndarray` instead of `ndarray`. This keeps the published docs aligned with source annotations and docstrings.

Fixes #8