### PR TITLE
Group API members by category and preserve source order

### DIFF
--- a/template/docs/mkdocs.yml.jinja
+++ b/template/docs/mkdocs.yml.jinja
@@ -163,7 +163,8 @@ plugins:
           paths: ['src'] # Change 'src' to your actual sources directory
           options:
             docstring_style: numpy
-            group_by_category: false
+            group_by_category: true
+            members_order: source
             heading_level: 1
             show_root_heading: true
             show_root_full_path: false


### PR DESCRIPTION
Update mkdocstrings configuration to group documented class members by category and keep members in source order within each section. 

Fixes #6 