### PR TITLE
Improve mkdocstring options

### DIFF
--- a/template/docs/mkdocs.yml.jinja
+++ b/template/docs/mkdocs.yml.jinja
@@ -170,8 +170,8 @@ plugins:
             show_root_heading: true
             show_root_full_path: false
             show_submodules: true
-            show_source: true
-            show_bases: true
+            show_source: false
+            show_bases: false
             # Uncomment when the project depends on `easyscience` and inherited
             # EasyScience base-class members should be shown in the API docs.
             # preload_modules:

--- a/template/docs/mkdocs.yml.jinja
+++ b/template/docs/mkdocs.yml.jinja
@@ -172,8 +172,10 @@ plugins:
             show_submodules: true
             show_source: true
             show_bases: true
-            preload_modules:
-              - easyscience
+            # Uncomment when the project depends on `easyscience` and inherited
+            # EasyScience base-class members should be shown in the API docs.
+            # preload_modules:
+            #   - easyscience
             inherited_members: true
             show_category_heading: true
             merge_init_into_class: true

--- a/template/docs/mkdocs.yml.jinja
+++ b/template/docs/mkdocs.yml.jinja
@@ -171,6 +171,15 @@ plugins:
             show_root_full_path: false
             show_submodules: true
             show_source: true
+            show_bases: true
+            preload_modules:
+              - easyscience
+            inherited_members: true
+            show_category_heading: true
+            merge_init_into_class: true
+            docstring_options:
+              ignore_init_summary: true
+            summary: true
   - search
 
 # Determines additional directories to watch when running mkdocs serve


### PR DESCRIPTION
Added more options to mkdocstrings. Some might be a matter of taste, but of semi-critical importance is `preload_modules` and `inherited_members`, which when combined pulls in methods from the easyscience base classes and show them in the API reference, like they should be.