### PR TITLE
Fix templates for deprecated Pixi system requirements API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,7 @@ Please make sure you follow the EasyScience organization-wide
 If you are not planning to contribute code, you may want to:
 
 - 🐞 Report a bug — see [Reporting Issues](#11-reporting-issues)
-- 🛡 Report a security issue — see
-  [Security Issues](#12-security-issues)
+- 🛡 Report a security issue — see [Security Issues](#12-security-issues)
 - 💬 Ask a question or start a discussion at
   [Project Discussions](https://github.com/easyscience/templates/discussions)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,19 @@
 [workspace]
 
 # Supported platforms for the lock file (pixi.lock)
-platforms = ['win-64', 'linux-64', 'osx-arm64']
+platforms = [
+  'win-64',
+  # Set minimum supported version for glibc to be 2.35 to ensure packages
+  # like `crysfml` that only have wheels for glibc 2.35+
+  # (manylinux_2_35_x86_64) are used.
+  #libc = { family = 'glibc', version = '2.35' }
+  { platform = 'linux-64', glibc = '2.35' },
+  # Set minimum supported version for macOS to be 14.0 to ensure packages
+  # like `scipp` that only have wheels for macOS 14.0+ (macosx_14_0_arm64)
+  # are used instead of building from source. This is a workaround for
+  # Pixi, see https://github.com/prefix-dev/pixi/issues/5667
+  { platform = 'osx-arm64', macos = '14.0' },
+]
 
 # Channels for fetching packages
 channels = ['nodefaults', 'conda-forge']
@@ -18,13 +30,6 @@ channels = ['nodefaults', 'conda-forge']
 
 [activation.env]
 PYTHONIOENCODING = 'utf-8'
-
-[system-requirements]
-# Set minimum supported version for macOS to be 14.0 to ensure packages
-# like `scipp` that only have wheels for macOS 14.0+ (macosx_14_0_arm64)
-# are used instead of building from source. This is a workaround for
-# Pixi, see https://github.com/prefix-dev/pixi/issues/5667
-macos = '14.0'
 
 # Non-default features:
 

--- a/template/.github/workflows/{{'' if template_type == 'lib' else '_exclude_'}}pypi-test.yml.jinja
+++ b/template/.github/workflows/{{'' if template_type == 'lib' else '_exclude_'}}pypi-test.yml.jinja
@@ -47,7 +47,9 @@ jobs:
 
       - name: Set the minimum system requirements
         working-directory: {{ lib_package_name }}
-        run: pixi project system-requirements add macos 14.0
+        run: |
+          pixi workspace platform add linux-64-glibc-2-35=linux-64 --glibc 2.35 --no-install
+          pixi workspace platform add osx-arm64-macos-14-0=osx-arm64 --macos 14.0 --no-install
 
       - name: Add Python {{ lib_python_max }} from Conda
         working-directory: {{ lib_package_name }}

--- a/template/.github/workflows/{{'' if template_type == 'lib' else '_exclude_'}}pypi-test.yml.jinja
+++ b/template/.github/workflows/{{'' if template_type == 'lib' else '_exclude_'}}pypi-test.yml.jinja
@@ -43,13 +43,13 @@ jobs:
           frozen: false
 
       - name: Init pixi project
-        run: pixi init {{ lib_package_name }}
+        run: pixi init --platform linux-64 --platform osx-arm64 --platform win-64 {{ lib_package_name }}
 
-      - name: Set the minimum system requirements
+      - name: Configure pixi platforms
         working-directory: {{ lib_package_name }}
         run: |
-          pixi workspace platform add linux-64-glibc-2-35=linux-64 --glibc 2.35 --no-install
-          pixi workspace platform add osx-arm64-macos-14-0=osx-arm64 --macos 14.0 --no-install
+          pixi workspace platform edit linux-64 --glibc 2.35 --no-install
+          pixi workspace platform edit osx-arm64 --macos 14.0 --no-install
 
       - name: Add Python {{ lib_python_max }} from Conda
         working-directory: {{ lib_package_name }}

--- a/template/.github/workflows/{{'' if template_type == 'lib' else '_exclude_'}}test.yml.jinja
+++ b/template/.github/workflows/{{'' if template_type == 'lib' else '_exclude_'}}test.yml.jinja
@@ -218,7 +218,7 @@ jobs:
             pixi add "python=$py_ver"
 
             echo "Setting macOS 14.0 as minimum required"
-            pixi project system-requirements add macos 14.0
+            pixi workspace platform add osx-arm64-macos-14-0=osx-arm64 --macos 14.0 --no-install
 
             echo "Looking for wheel in ../dist/py$py_ver/"
             ls -l "../dist/py$py_ver/"

--- a/template/.github/workflows/{{'' if template_type == 'lib' else '_exclude_'}}test.yml.jinja
+++ b/template/.github/workflows/{{'' if template_type == 'lib' else '_exclude_'}}test.yml.jinja
@@ -211,14 +211,15 @@ jobs:
             echo "🔹🔸🔹🔸🔹 Python: $py_ver 🔹🔸🔹🔸🔹"
 
             echo "Initializing pixi project"
-            pixi init {{ lib_package_name }}_py$py_ver
+            pixi init --platform linux-64 --platform osx-arm64 --platform win-64 e{{ lib_package_name }}_py$py_ver
             cd {{ lib_package_name }}_py$py_ver
+
+            echo "Configure pixi platforms"
+            pixi workspace platform edit linux-64 --glibc 2.35 --no-install
+            pixi workspace platform edit osx-arm64 --macos 14.0 --no-install
 
             echo "Adding Python $py_ver"
             pixi add "python=$py_ver"
-
-            echo "Setting macOS 14.0 as minimum required"
-            pixi workspace platform add osx-arm64-macos-14-0=osx-arm64 --macos 14.0 --no-install
 
             echo "Looking for wheel in ../dist/py$py_ver/"
             ls -l "../dist/py$py_ver/"


### PR DESCRIPTION
Updates the Pixi config and CI workflow templates to use the new `workspace.platforms` API instead of the deprecated `[system-requirements]` section. This sets Linux `glibc 2.35` and macOS `14.0` through platform entries so generated projects resolve compatible wheels with newer Pixi versions.

After applying these templates, run `pixi run prettier-install` to update Prettier to `3.9.4`.