### PR TITLE
Fix generated package-test project directory name

### DIFF
--- a/template/.github/workflows/{{'' if template_type == 'lib' else '_exclude_'}}test.yml.jinja
+++ b/template/.github/workflows/{{'' if template_type == 'lib' else '_exclude_'}}test.yml.jinja
@@ -211,7 +211,7 @@ jobs:
             echo "🔹🔸🔹🔸🔹 Python: $py_ver 🔹🔸🔹🔸🔹"
 
             echo "Initializing pixi project"
-            pixi init --platform linux-64 --platform osx-arm64 --platform win-64 e{{ lib_package_name }}_py$py_ver
+            pixi init --platform linux-64 --platform osx-arm64 --platform win-64 {{ lib_package_name }}_py$py_ver
             cd {{ lib_package_name }}_py$py_ver
 
             echo "Configure pixi platforms"


### PR DESCRIPTION
The library test workflow template initialized the package-test Pixi project as `e{{ lib_package_name }}_py$py_ver` but later entered `{{ lib_package_name }}_py$py_ver` causing CI package-test jobs to fail immediately. This PR removes the extra leading e so the generated init and cd paths match.