### PR TITLE
Exclude broken docstring-parser-fork 0.0.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
   'jupytext',                        # Jupyter notebook text format support
   'jupyterquiz',                     # Quizzes in Jupyter notebooks
   'pydoclint',                       # Docstring linter
+  'docstring-parser-fork!=0.0.15',   # Parser used by pydoclint. 0.0.15 splits NumPy-style defaults -> DOC105 failures
   'format-docstring',                # Docstring formatter
   'docstripy',                       # Convert docstrings to other formats
   'interrogate',                     # Docstring coverage checker

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -60,6 +60,7 @@ dev = [
   'jupytext',                        # Jupyter notebook text format support
   'jupyterquiz',                     # Quizzes in Jupyter notebooks
   'pydoclint',                       # Docstring linter
+  'docstring-parser-fork!=0.0.15',   # Parser used by pydoclint. 0.0.15 splits NumPy-style defaults -> DOC105 failures
   'format-docstring',                # Docstring formatter
   'docstripy',                       # Convert docstrings to other formats
   'interrogate',                     # Docstring coverage checker


### PR DESCRIPTION
Adds docstring-parser-fork!=0.0.15 to the dev dependencies in both the project and template pyproject.toml files to avoid pydoclint DOC105 failures caused by NumPy-style default parsing in that release.